### PR TITLE
Updates query.rb parameter

### DIFF
--- a/lib/import_export/query.rb
+++ b/lib/import_export/query.rb
@@ -19,7 +19,7 @@ module ImportExport
       address: nil,
       name: nil,
       fuzzy_name: false,
-      type: nil,
+      types: nil,
       size: 100,
       offset: 0
     }.freeze


### PR DESCRIPTION
It appears that the OFAC endpoint has updated one of the query parameters from `type` to `types`. This means that our current parameter queries fail and return bad data for the analysts.